### PR TITLE
Update CSProj to use new AviationCalcUtilNet

### DIFF
--- a/NavData-Interface/NavData-Interface.csproj
+++ b/NavData-Interface/NavData-Interface.csproj
@@ -3,15 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>NavData_Interface</RootNamespace>
-    <Platforms>x86;x64</Platforms>
-	<RunId Condition="'$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Windows'))">win-$(Platform)</RunId>
-    <RunId Condition="'$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Linux'))">linux-$(Platform)</RunId>
-    <RunId Condition="'$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('OSX'))">osx-$(Platform)</RunId>
-    <RunId Condition="'$(RunId)' == ''">$(RuntimeIdentifier)</RunId>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PShivaraman.AviationCalcUtilNet.$(RunId)" Version="1.0.12" />
+    <PackageReference Include="PShivaraman.AviationCalcUtilNet" Version="1.1.2" />
     <PackageReference Include="SQLite" Version="3.13.0" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.117" />
   </ItemGroup>


### PR DESCRIPTION
This should eliminate the need to build platform specific binaries here.